### PR TITLE
feat(auth): Enhance password reset security and remove Remember Me

### DIFF
--- a/app/api/auth/forgot-password/route.js
+++ b/app/api/auth/forgot-password/route.js
@@ -17,6 +17,12 @@ export async function POST(request) {
       return NextResponse.json({ message: 'If your email is in our system, you will receive a password reset link.' }, { status: 200 });
     }
 
+    // Update user status to indicate password reset is pending
+    await db.user.update({
+      where: { id: user.id },
+      data: { status: 'PENDING_PASSWORD_RESET' },
+    });
+
     // 2. Generate a short-lived JWT
     const token = jwt.sign(
       { userId: user.id, email: user.email },

--- a/app/api/auth/reset-password/route.js
+++ b/app/api/auth/reset-password/route.js
@@ -27,13 +27,22 @@ export async function POST(request) {
       return NextResponse.json({ message: 'User not found.' }, { status: 404 });
     }
 
+    // Check if the new password is the same as the old one
+    const isSamePassword = await bcrypt.compare(password, user.password);
+    if (isSamePassword) {
+      return NextResponse.json({ message: 'New password cannot be the same as the old password.' }, { status: 400 });
+    }
+
     // 3. Hash the new password
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    // 4. Update the user's password in the database
+    // 4. Update the user's password and status in the database
     await db.user.update({
       where: { id: userId },
-      data: { password: hashedPassword },
+      data: { 
+        password: hashedPassword,
+        status: 'ACTIVE' // Reactivate the account
+      },
     });
 
     return NextResponse.json({ message: 'Password has been reset successfully.' }, { status: 200 });

--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -12,7 +12,6 @@ export default function LoginPage() {
   });
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [rememberMe, setRememberMe] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
 
@@ -22,23 +21,22 @@ export default function LoginPage() {
     setError("");
 
     try {
+      // Let NextAuth handle the redirect. It's more reliable for setting cookies.
       const result = await signIn("credentials", {
         email: formData.email,
         password: formData.password,
-        redirect: false,
+        callbackUrl: "/dashboard", // Redirect to dashboard on success
       });
 
+      // This part will likely not be reached if signIn redirects,
+      // but it's good practice to handle a failed signIn call that doesn't redirect.
       if (result?.error) {
         setError("Invalid email or password");
-      } else {
-        const session = await getSession();
-        if (session) {
-          router.push("/dashboard");
-        }
+        setLoading(false);
       }
     } catch (error) {
-      setError("Something went wrong");
-    } finally {
+      // This will catch network errors or other unexpected issues.
+      setError("An unexpected error occurred. Please try again.");
       setLoading(false);
     }
   };
@@ -118,17 +116,7 @@ export default function LoginPage() {
 
           <div className="flex items-center justify-between">
             <div className="flex items-center">
-              <input
-                id="remember-me"
-                name="remember-me"
-                type="checkbox"
-                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded"
-                checked={rememberMe}
-                onChange={(e) => setRememberMe(e.target.checked)}
-              />
-              <label htmlFor="remember-me" className="ml-2 block text-sm text-gray-900">
-                Remember me
-              </label>
+              {/* "Remember me" checkbox has been removed */}
             </div>
 
             <div className="text-sm">

--- a/lib/authOptions.js
+++ b/lib/authOptions.js
@@ -2,7 +2,7 @@
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import bcrypt from "bcrypt";
+import bcrypt from "bcryptjs";
 import prisma from "./db";
 
 export const authOptions = {
@@ -27,6 +27,12 @@ export const authOptions = {
 
         if (!user || !user.password) {
           return null;
+        }
+        
+        // Check if the user's account is active
+        if (user.status !== 'ACTIVE') {
+          console.log(`Login failed for ${user.email}: Account status is ${user.status}`);
+          throw new Error('Account is not active. Please check your email or contact support.');
         }
 
         const isPasswordValid = await bcrypt.compare(

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,13 @@ enum Role {
   STAFF
 }
 
+enum UserStatus {
+  ACTIVE
+  PENDING_PASSWORD_RESET
+  SUSPENDED
+  DEACTIVATED
+}
+
 model User {
   id            String        @id @default(auto()) @map("_id") @db.ObjectId
   name          String?
@@ -55,6 +62,7 @@ model User {
   password      String?
   image         String?
   role          Role          @default(STAFF)
+  status        UserStatus    @default(ACTIVE)
   accounts      Account[]
   sessions      Session[]
   activityLogs  ActivityLog[]


### PR DESCRIPTION
This commit introduces significant security enhancements to the user authentication and password reset flow. It also removes the non-functional 'Remember Me' feature for a cleaner codebase.

Security Enhancements:
- **User Status Implementation:** Added a  field (, , etc.) to the User model to manage account states.
- **Invalidate Old Password:** When a user requests a password reset, their account status is set to . Users cannot log in with their old password while in this state. The status is reset to  upon successful password change.
- **Prevent Password Reuse:** Added a check to ensure that a user's new password cannot be the same as their old one.

Code Cleanup:
- **Removed 'Remember Me' Feature:** The 'Remember Me' checkbox and all related backend logic for persistent sessions have been completely removed due to implementation issues, simplifying the auth configuration.